### PR TITLE
Add "Simplified" and "Traditional" to the Chinese language names

### DIFF
--- a/splat3/database.html
+++ b/splat3/database.html
@@ -569,7 +569,7 @@
                     ext: "CNzh",
                     region: "AP",
                     language: "cn",
-                    name: "中文",
+                    name: "中文（简体）",
                 },
                 {
                     ext: "KRko",
@@ -581,7 +581,7 @@
                     ext: "TWzh",
                     region: "AP",
                     language: "tw",
-                    name: "中文",
+                    name: "中文（繁體）",
                 },
             ]
 

--- a/splat3/manuals.html
+++ b/splat3/manuals.html
@@ -514,7 +514,7 @@
                         ext: "CNzh",
                         region: "AP",
                         language: "cn",
-                        name: "中文",
+                        name: "中文（简体）",
                     },
                     {
                         ext: "KRko",
@@ -526,7 +526,7 @@
                         ext: "TWzh",
                         region: "AP",
                         language: "tw",
-                        name: "中文",
+                        name: "中文（繁體）",
                     },
                 ]
 

--- a/splat3/title.html
+++ b/splat3/title.html
@@ -259,7 +259,7 @@
                     ext: "CNzh",
                     region: "AP",
                     language: "cn",
-                    name: "中文",
+                    name: "中文（简体）",
                 },
                 {
                     ext: "KRko",
@@ -271,7 +271,7 @@
                     ext: "TWzh",
                     region: "AP",
                     language: "tw",
-                    name: "中文",
+                    name: "中文（繁體）",
                 },
             ]
 


### PR DESCRIPTION
Currently in the language dropdowns both Traditional and Simplified Chinese just show up as 中文 (Chinese). This makes the name for Simplified Chinese 中文（简体）and the name for Traditional Chinese 中文（繁體）.